### PR TITLE
apply fare refunds to drt rides

### DIFF
--- a/src/main/java/org/matsim/drt/ChainedPtAndDrtFareHandler.java
+++ b/src/main/java/org/matsim/drt/ChainedPtAndDrtFareHandler.java
@@ -29,6 +29,7 @@ public class ChainedPtAndDrtFareHandler implements PtFareHandler {
 	@Inject
 	private EventsManager events;
 	private static final String DRT_INTERACTION = ScoringConfigGroup.createStageActivityType(TransportMode.drt);
+	public static final String DRT_OR_PT_FARE = "drt or drt-pt intermodal fare";
 
 	private final Map<Id<Person>, Coord> personDepartureCoordMap = new HashMap<>();
 	private final Map<Id<Person>, Coord> personArrivalCoordMap = new HashMap<>();
@@ -69,7 +70,7 @@ public class ChainedPtAndDrtFareHandler implements PtFareHandler {
 
 		// charge fare to the person
 		events.processEvent(new PersonMoneyEvent(event.getTime(), event.getPersonId(), -fare.fare(),
-			personInvolvedInDrtTrip.contains(personId)? "drt or drt-pt intermodal fare" : PtFareConfigGroup.PT_FARE,
+			personInvolvedInDrtTrip.contains(personId)? DRT_OR_PT_FARE : PtFareConfigGroup.PT_FARE,
 			fare.transactionPartner(), event.getPersonId().toString()));
 
 		personDepartureCoordMap.remove(personId);

--- a/src/main/java/org/matsim/drt/PtAndDrtFareModule.java
+++ b/src/main/java/org/matsim/drt/PtAndDrtFareModule.java
@@ -1,0 +1,56 @@
+package org.matsim.drt;
+
+import com.google.inject.multibindings.Multibinder;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.contrib.vsp.pt.fare.*;
+import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.AbstractModule;
+
+import java.net.URL;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+/**
+ * This Module replaces the usual PtFareModule (core) when DRT is used as intermodal connection to/from PT with the same fare as PT.
+ */
+public class PtAndDrtFareModule extends AbstractModule {
+
+	@Override
+	public void install() {
+		getConfig().scoring().getModes().get(TransportMode.pt).setDailyMonetaryConstant(0);
+		getConfig().scoring().getModes().get(TransportMode.pt).setMarginalUtilityOfDistance(0);
+		Multibinder<PtFareCalculator> ptFareCalculator = Multibinder.newSetBinder(binder(), PtFareCalculator.class);
+
+		PtFareConfigGroup ptFareConfigGroup = ConfigUtils.addOrGetModule(this.getConfig(), PtFareConfigGroup.class);
+		Collection<? extends ConfigGroup> fareZoneBased = ptFareConfigGroup.getParameterSets(FareZoneBasedPtFareParams.SET_TYPE);
+		Collection<? extends ConfigGroup> distanceBased = ptFareConfigGroup.getParameterSets(DistanceBasedPtFareParams.SET_TYPE);
+
+		URL context = getConfig().getContext();
+
+		Stream.concat(fareZoneBased.stream(), distanceBased.stream())
+			  .map(c -> (PtFareParams) c)
+			  .sorted(Comparator.comparing(PtFareParams::getOrder))
+			  .forEach(p -> {
+				  if (p instanceof FareZoneBasedPtFareParams fareZoneBasedPtFareParams) {
+					  ptFareCalculator.addBinding().toInstance(new FareZoneBasedPtFareCalculator(fareZoneBasedPtFareParams, context));
+				  } else if (p instanceof DistanceBasedPtFareParams distanceBasedPtFareParams) {
+					  ptFareCalculator.addBinding().toInstance(new DistanceBasedPtFareCalculator(distanceBasedPtFareParams, context));
+				  } else {
+					  throw new RuntimeException("Unknown PtFareParams: " + p.getClass());
+				  }
+			  });
+
+		bind(ChainedPtFareCalculator.class);
+		bind(PtFareHandler.class).to(ChainedPtAndDrtFareHandler.class);
+		addEventHandlerBinding().to(PtFareHandler.class);
+
+		if (ptFareConfigGroup.getApplyUpperBound()) {
+//			use upper bound handler which also considers DRT/PT intermodal rides
+			PtAndDrtFareUpperBoundHandler ptAndDrtFareUpperBoundHandler = new PtAndDrtFareUpperBoundHandler(ptFareConfigGroup.getUpperBoundFactor());
+			addEventHandlerBinding().toInstance(ptAndDrtFareUpperBoundHandler);
+			addControlerListenerBinding().toInstance(ptAndDrtFareUpperBoundHandler);
+		}
+	}
+}

--- a/src/main/java/org/matsim/drt/PtAndDrtFareUpperBoundHandler.java
+++ b/src/main/java/org/matsim/drt/PtAndDrtFareUpperBoundHandler.java
@@ -1,0 +1,96 @@
+package org.matsim.drt;
+
+import com.google.inject.Inject;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.events.PersonMoneyEvent;
+import org.matsim.api.core.v01.events.handler.PersonMoneyEventHandler;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contrib.vsp.pt.fare.PtFareConfigGroup;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.groups.QSimConfigGroup;
+import org.matsim.core.controler.events.AfterMobsimEvent;
+import org.matsim.core.controler.listener.AfterMobsimListener;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.matsim.drt.ChainedPtAndDrtFareHandler.DRT_OR_PT_FARE;
+
+/**
+ * This class will calculate the potential refund a PT user will get because of the upper bound of the daily fare (
+ * e.g. ticket subscription). If the upper bound is reached, refund will be issued at the end of the
+ * iteration (i.e. after Mobsim). In that case, we assume that PT user is a frequent traveller and will use subscription
+ * instead of single tickets.
+ * @author Chengqi Lu (luchengqi7)
+ */
+public class PtAndDrtFareUpperBoundHandler implements PersonMoneyEventHandler, AfterMobsimListener {
+	public static final String PT_REFUND = "pt fare refund";
+
+	private double mobsimEndTime = Double.NaN;
+	private final double upperBoundFactor;
+
+	@Inject
+	private EventsManager events;
+	@Inject
+	private QSimConfigGroup qSimConfigGroup;
+
+	private final Map<Id<Person>, List<Double>> ptFareRecords = new HashMap<>();
+
+	public PtAndDrtFareUpperBoundHandler(double upperBoundFactor) {
+		this.upperBoundFactor = upperBoundFactor;
+	}
+
+	@Override
+	public void handleEvent(PersonMoneyEvent event) {
+		if (event.getPurpose().equals(PtFareConfigGroup.PT_FARE) ||
+			event.getPurpose().equals(DRT_OR_PT_FARE)) {
+			Id<Person> personId = event.getPersonId();
+			ptFareRecords.computeIfAbsent(personId, l -> new ArrayList<>()).add(event.getAmount() * -1);
+		}
+	}
+
+	@Override
+	public void reset(int iteration) {
+		ptFareRecords.clear();
+	}
+	@Override
+	public void notifyAfterMobsim(AfterMobsimEvent event) {
+		for (Id<Person> personId : ptFareRecords.keySet()) {
+			double refund = calculateRefund(ptFareRecords.get(personId));
+			if (refund > 0) {
+				// Issue refund to person
+				events.processEvent(
+					new PersonMoneyEvent(getOrCalcCompensationTime(), personId, refund,
+						PT_REFUND, TransportMode.pt, "Refund for person " + personId.toString()));
+			}
+		}
+	}
+
+	private double calculateRefund(List<Double> fares) {
+		double sum = 0;
+		double maxFare = 0;
+		for (double fare : fares) {
+			sum += fare;
+			if (fare > maxFare) {
+				maxFare = fare;
+			}
+		}
+		double upperBound = maxFare * upperBoundFactor;
+		if (sum > upperBound) {
+			return sum - upperBound;
+		}
+		return 0;
+	}
+
+	private double getOrCalcCompensationTime() {
+		if (Double.isNaN(this.mobsimEndTime)) {
+			this.mobsimEndTime = (Double.isFinite(qSimConfigGroup.getEndTime().seconds()) && qSimConfigGroup.getEndTime().seconds() > 0)
+				? qSimConfigGroup.getEndTime().seconds()
+				: Double.MAX_VALUE;
+		}
+		return this.mobsimEndTime;
+	}
+}

--- a/src/main/java/org/matsim/run/scenarios/LausitzDrtScenario.java
+++ b/src/main/java/org/matsim/run/scenarios/LausitzDrtScenario.java
@@ -16,14 +16,14 @@ import org.matsim.contrib.dvrp.passenger.PassengerRequestValidator;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpModule;
 import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
-import org.matsim.contrib.vsp.pt.fare.PtFareHandler;
+import org.matsim.contrib.vsp.pt.fare.PtFareModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.dashboards.LausitzDrtDashboard;
-import org.matsim.drt.ChainedPtAndDrtFareHandler;
+import org.matsim.drt.PtAndDrtFareModule;
 import org.matsim.drt.ShpBasedDrtRequestValidator;
 import org.matsim.run.DrtOptions;
 import org.matsim.simwrapper.SimWrapper;
@@ -121,10 +121,6 @@ public final class LausitzDrtScenario extends LausitzScenario {
 							.setRideDurationDistributionGenerator(new NormalDistributionGenerator(2, drtOpt.getRideTimeStd()))
 							.build()
 					);
-
-					if (drtOpt.getFareHandling() == DrtOptions.FunctionalityHandling.ENABLED) {
-						bind(PtFareHandler.class).to(ChainedPtAndDrtFareHandler.class);
-					}
 				}
 			});
 
@@ -136,6 +132,19 @@ public final class LausitzDrtScenario extends LausitzScenario {
 						modalProvider(getter -> new ShpBasedDrtRequestValidator(shp))).asEagerSingleton();
 				}
 			});
+		}
+	}
+
+
+//	this method overrides the getPtFareModule method in LausitzScenario (parent class).
+//	for DRT we need an upperBoundHandler which gives fare refunds when using pt OR drt.
+//	the handler is added in PtAndDrtFareModule. -sm0525
+	@Override
+	public AbstractModule getPtFareModule() {
+		if (drtOpt.getFareHandling() == DrtOptions.FunctionalityHandling.ENABLED) {
+			return new PtAndDrtFareModule();
+		} else {
+			return new PtFareModule();
 		}
 	}
 }

--- a/src/main/java/org/matsim/run/scenarios/LausitzScenario.java
+++ b/src/main/java/org/matsim/run/scenarios/LausitzScenario.java
@@ -87,7 +87,6 @@ public class LausitzScenario extends MATSimApplication {
 	@CommandLine.Option(names = "--emissions", defaultValue = "PERFORM_EMISSIONS_ANALYSIS", description = "Define if emission analysis should be performed or not.")
 	EmissionAnalysisHandling emissions;
 
-
 	public LausitzScenario(@Nullable Config config) {
 		super(config);
 	}
@@ -217,7 +216,7 @@ public class LausitzScenario extends MATSimApplication {
 		controler.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {
-				install(new PtFareModule());
+				install(getPtFareModule());
 				bind(ScoringParametersForPerson.class).to(IncomeDependentUtilityOfMoneyPersonScoringParameters.class).asEagerSingleton();
 
 				addTravelTimeBinding(TransportMode.ride).to(networkTravelTime());
@@ -327,6 +326,11 @@ public class LausitzScenario extends MATSimApplication {
 		scenario.getTransitVehicles()
 			.getVehicleTypes()
 			.values().forEach(type -> VehicleUtils.setHbefaVehicleCategory(type.getEngineInformation(), HbefaVehicleCategory.NON_HBEFA_VEHICLE.toString()));
+	}
+
+//	overridable method to implement custom PtFareModules in policy scenarios.
+	public AbstractModule getPtFareModule() {
+		return new PtFareModule();
 	}
 
 	/**


### PR DESCRIPTION
workaround to also consider drt rides for fare refunds. The current default implementation considers pt rides only for refunding fare cost above upper bound.